### PR TITLE
BTR-3060 | Add support for loading props on images

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -76,7 +76,7 @@
      * Base URI Defaults to `https://media.graphcms.com`
      */
     baseURI?: string
-    loading?: string
+    loading?: HTMLImageElement['loading']
   }
 
   export default class GraphImage extends React.Component<GraphImageProps> {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,6 +76,7 @@
      * Base URI Defaults to `https://media.graphcms.com`
      */
     baseURI?: string
+    loading?: string
   }
 
   export default class GraphImage extends React.Component<GraphImageProps> {}

--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,8 @@ class GraphImage extends React.Component {
       blurryPlaceholder,
       backgroundColor,
       fadeIn,
-      baseURI
+      baseURI,
+      loading
     } = this.props;
 
     let {
@@ -198,6 +199,7 @@ class GraphImage extends React.Component {
                 src={thumbSrc}
                 opacity={this.state.imgLoaded ? 0 : 1}
                 transitionDelay="0.25s"
+                loading={loading}
               />
             )}
 
@@ -228,6 +230,7 @@ class GraphImage extends React.Component {
                 sizes={sizes}
                 opacity={this.state.imgLoaded || !fadeIn ? 1 : 0}
                 onLoad={this.onImageLoaded}
+                loading={loading}
               />
             )}
           </div>
@@ -253,7 +256,8 @@ GraphImage.defaultProps = {
   backgroundColor: '',
   fadeIn: true,
   onLoad: null,
-  baseURI: 'https://media.graphassets.com'
+  baseURI: 'https://media.graphassets.com',
+  loading: 'lazy',
 };
 
 GraphImage.propTypes = {
@@ -279,7 +283,8 @@ GraphImage.propTypes = {
   blurryPlaceholder: PropTypes.bool,
   backgroundColor: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   fadeIn: PropTypes.bool,
-  baseURI: PropTypes.string
+  baseURI: PropTypes.string,
+  loading: PropTypes.string
 };
 
 export default GraphImage


### PR DESCRIPTION
Adding props support for loading, so we can set images to lazy loading (the default) or eager loading within the hiburrow app.